### PR TITLE
feat: support per-chaincode image override in CCaaS compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
       - "**"
 
 jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install -r requirements.txt
+      - name: Run unit tests
+        run: make test
+        timeout-minutes: 5
+
   build:
     runs-on: ubuntu-22.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+.tmp/
+__pycache__/
 
 # files that are generated as part of the network-builder template
 docker-compose-e2e.yaml  # generated docker compose file

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ default: docker-build
 clean:
 	rm -fr build
 
+.PHONY: test
+test:
+	python3 -m unittest discover -s tests -v
+
 .PHONY: docker-build
 docker-build: ${DOCKER_IMAGE_TARGET}
 	@

--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ container.
 docker exec -it cli bash ./scripts/install.sh mychannel mycc v1.0 chaincode.car
 ```
 
+## Chaincode as a Service (CCaaS)
+
+`generatecc --ccaas` packages each chaincode variant as a CCaaS stub and emits
+`docker-compose-ccaas.yaml` with one service per variant. Every service runs
+the `luthersystems/substrate:$CHAINCODE_VERSION` image by default (substrate
+phyla use this path).
+
+To run a non-substrate CCaaS container alongside substrate phyla, pass
+`--image-override NAME=IMAGE` (repeatable). `NAME` must match a variant listed
+in `cc_variants`; an unknown name exits with a non-zero status.
+
+```bash
+fabric-network-builder generatecc --ccaas \
+    --image-override external=luthersystems/externalcc:$CHAINCODE_VERSION \
+    mycc v1.0 "a b external" /path/to/chaincode.car
+```
+
+With that invocation the generated compose file assigns
+`luthersystems/externalcc:$CHAINCODE_VERSION` to `external-peer0` and leaves
+`a-peer0`/`b-peer0` on the substrate default.
+
 ## Network teardown
 
 When finished using the network use byfn.sh to stop/remove containers and

--- a/network.py
+++ b/network.py
@@ -327,6 +327,8 @@ class Network(object):
             cc_variants: string
             cc_path: string
         '''
+        if args.image_override and not args.ccaas:
+            raise SystemExit("--image-override requires --ccaas")
         byfn_cmd = self._byfn_cmd('generatecc')
         append_opt(byfn_cmd, '-C', args.cc_name)
         append_opt(byfn_cmd, '-V', args.cc_version)
@@ -352,6 +354,9 @@ class Network(object):
                 raise SystemExit(
                     f"--image-override NAME {name!r} is not in cc_variants "
                     f"({sorted(valid)})")
+            if name in out:
+                raise SystemExit(
+                    f"--image-override NAME {name!r} specified more than once")
             out[name] = image
         return out
 

--- a/network.py
+++ b/network.py
@@ -335,12 +335,31 @@ class Network(object):
         if args.ccaas:
             byfn_cmd.append('-x')
         run(byfn_cmd, chdir=self.destination_path, setenv=self._compose_setenv())
-        self.generate_chaincodes_compose(args.cc_variants.split())
+        self.generate_chaincodes_compose(args.cc_variants.split(), args.image_override)
 
-    def generate_chaincodes_compose(self, chaincode_names):
+    DEFAULT_CCAAS_IMAGE = 'luthersystems/substrate:$CHAINCODE_VERSION'
+
+    @staticmethod
+    def _parse_image_overrides(pairs, valid_names):
+        valid = set(valid_names)
+        out = {}
+        for p in pairs:
+            name, sep, image = p.partition('=')
+            if not sep or not name or not image:
+                raise SystemExit(
+                    f"--image-override expects NAME=IMAGE, got {p!r}")
+            if name not in valid:
+                raise SystemExit(
+                    f"--image-override NAME {name!r} is not in cc_variants "
+                    f"({sorted(valid)})")
+            out[name] = image
+        return out
+
+    def generate_chaincodes_compose(self, chaincode_names, image_overrides=None):
         if len(chaincode_names) == 0:
             print("skipping ccaas compose file...")
             return
+        overrides = self._parse_image_overrides(image_overrides or [], chaincode_names)
         # Define the base port for the external chaincodes
         base_port = 9080
 
@@ -350,7 +369,8 @@ class Network(object):
             chaincodes_data.append({
                 'service_name': f"{cc_name}-peer0",
                 'ccid_env_var': f"CCID_{cc_name.upper()}",
-                'port': base_port + idx
+                'port': base_port + idx,
+                'image': overrides.get(cc_name, self.DEFAULT_CCAAS_IMAGE),
             })
 
         # Load and render the Jinja template
@@ -506,6 +526,11 @@ class Network(object):
         parser_generatecc = subparsers.add_parser('generatecc', help='generate chaincode archives (.tar.gz)')
         parser_generatecc.add_argument('--ccaas', help='use chaincode as a service',
                                     action='store_true')
+        parser_generatecc.add_argument('--image-override',
+                                    action='append', default=[], dest='image_override',
+                                    metavar='NAME=IMAGE',
+                                    help='override image for a CCaaS service (repeatable); '
+                                         'NAME must match a chaincode in cc_variants')
         parser_generatecc.add_argument('cc_name', help='chaincode name used to invoke its methods')
         parser_generatecc.add_argument('cc_version', help='deployment version')
         parser_generatecc.add_argument('cc_variants', help='deployment variants')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.1
-Jinja2==3.1.4
-cryptography==42.0.4
-pyOpenSSL==24.0.0
+Jinja2==3.1.6
+cryptography==46.0.7
+pyOpenSSL==26.0.0

--- a/template/docker-compose-ccaas.yaml.j2
+++ b/template/docker-compose-ccaas.yaml.j2
@@ -2,7 +2,7 @@ version: '3.7'
 services:
 {%- for cc in chaincodes %}
   {{ cc.service_name }}:
-    image: luthersystems/substrate:$CHAINCODE_VERSION
+    image: {{ cc.image }}
     command: ["${{ cc.ccid_env_var }}"]
     ports:
       - "{{ cc.port }}:8080"

--- a/tests/test_generatecc.py
+++ b/tests/test_generatecc.py
@@ -3,9 +3,13 @@ import sys
 import tempfile
 import unittest
 
+import yaml
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from network import Network  # noqa: E402
+
+SUBSTRATE_DEFAULT = 'luthersystems/substrate:$CHAINCODE_VERSION'
 
 
 def _make_net(dest):
@@ -17,51 +21,66 @@ def _make_net(dest):
     return n
 
 
-def _rendered(dest):
-    with open(os.path.join(dest, 'docker-compose-ccaas.yaml')) as f:
-        return f.read()
+def _render(chaincode_names, image_overrides=None):
+    with tempfile.TemporaryDirectory() as d:
+        _make_net(d).generate_chaincodes_compose(chaincode_names, image_overrides)
+        with open(os.path.join(d, 'docker-compose-ccaas.yaml')) as f:
+            return f.read()
 
 
-class GenerateChaincodesComposeTest(unittest.TestCase):
+class ImageOverrideTest(unittest.TestCase):
     def test_default_image_when_no_override(self):
-        with tempfile.TemporaryDirectory() as d:
-            _make_net(d).generate_chaincodes_compose(['a', 'b'])
-            out = _rendered(d)
-        self.assertIn('a-peer0:', out)
-        self.assertIn('b-peer0:', out)
-        self.assertEqual(out.count('image: luthersystems/substrate:$CHAINCODE_VERSION'), 2)
+        parsed = yaml.safe_load(_render(['a', 'b']))
+        self.assertEqual(parsed['services']['a-peer0']['image'], SUBSTRATE_DEFAULT)
+        self.assertEqual(parsed['services']['b-peer0']['image'], SUBSTRATE_DEFAULT)
 
     def test_override_applies_only_to_named_service(self):
-        with tempfile.TemporaryDirectory() as d:
-            _make_net(d).generate_chaincodes_compose(
-                ['a', 'external'],
-                ['external=luthersystems/externalcc:$CHAINCODE_VERSION'])
-            out = _rendered(d)
-        a_block = out.split('a-peer0:', 1)[1].split('external-peer0:', 1)[0]
-        ext_block = out.split('external-peer0:', 1)[1]
-        self.assertIn('image: luthersystems/substrate:$CHAINCODE_VERSION', a_block)
-        self.assertIn('image: luthersystems/externalcc:$CHAINCODE_VERSION', ext_block)
-        self.assertNotIn('image: luthersystems/substrate', ext_block.split('\n', 5)[1])
+        parsed = yaml.safe_load(_render(
+            ['a', 'external'],
+            ['external=luthersystems/externalcc:$CHAINCODE_VERSION']))
+        self.assertEqual(parsed['services']['a-peer0']['image'], SUBSTRATE_DEFAULT)
+        self.assertEqual(
+            parsed['services']['external-peer0']['image'],
+            'luthersystems/externalcc:$CHAINCODE_VERSION')
+
+    def test_image_value_containing_equals_sign_preserved(self):
+        # Guards against a future `.split('=')` refactor; partition splits on first '='.
+        parsed = yaml.safe_load(_render(
+            ['a'], ['a=registry.io/img:tag?k=v']))
+        self.assertEqual(parsed['services']['a-peer0']['image'], 'registry.io/img:tag?k=v')
 
     def test_unknown_name_exits(self):
-        with tempfile.TemporaryDirectory() as d:
-            with self.assertRaises(SystemExit) as cm:
-                _make_net(d).generate_chaincodes_compose(['a'], ['foo=bar:1'])
-            self.assertIn("'foo'", str(cm.exception))
+        with self.assertRaises(SystemExit) as cm:
+            _render(['a'], ['foo=bar:1'])
+        self.assertIn("'foo'", str(cm.exception))
+        self.assertIn("cc_variants", str(cm.exception))
 
     def test_malformed_pair_exits(self):
-        with tempfile.TemporaryDirectory() as d:
-            with self.assertRaises(SystemExit):
-                _make_net(d).generate_chaincodes_compose(['a'], ['no-equals-sign'])
-            with self.assertRaises(SystemExit):
-                _make_net(d).generate_chaincodes_compose(['a'], ['=bar'])
-            with self.assertRaises(SystemExit):
-                _make_net(d).generate_chaincodes_compose(['a'], ['a='])
+        for pair in ('no-equals-sign', '=bar', 'a='):
+            with self.subTest(pair=pair):
+                with self.assertRaises(SystemExit) as cm:
+                    _render(['a'], [pair])
+                self.assertIn('--image-override expects NAME=IMAGE', str(cm.exception))
+
+    def test_duplicate_name_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            _render(['a'], ['a=one:1', 'a=two:2'])
+        self.assertIn("'a'", str(cm.exception))
+        self.assertIn('more than once', str(cm.exception))
 
     def test_empty_cc_list_skips(self):
         with tempfile.TemporaryDirectory() as d:
             _make_net(d).generate_chaincodes_compose([])
             self.assertFalse(os.path.exists(os.path.join(d, 'docker-compose-ccaas.yaml')))
+
+    def test_image_override_requires_ccaas(self):
+        import argparse
+        args = argparse.Namespace(
+            ccaas=False, image_override=['a=foo:1'],
+            cc_name='a', cc_version='v1', cc_variants='a', cc_path='/tmp/x')
+        with self.assertRaises(SystemExit) as cm:
+            _make_net('/tmp').generate_chaincodes(args)
+        self.assertIn('--image-override requires --ccaas', str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/tests/test_generatecc.py
+++ b/tests/test_generatecc.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from network import Network  # noqa: E402
+
+
+def _make_net(dest):
+    n = object.__new__(Network)
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    n.template_base_path = os.path.join(repo_root, 'template')
+    n.destination_path = dest
+    n.chown = None
+    return n
+
+
+def _rendered(dest):
+    with open(os.path.join(dest, 'docker-compose-ccaas.yaml')) as f:
+        return f.read()
+
+
+class GenerateChaincodesComposeTest(unittest.TestCase):
+    def test_default_image_when_no_override(self):
+        with tempfile.TemporaryDirectory() as d:
+            _make_net(d).generate_chaincodes_compose(['a', 'b'])
+            out = _rendered(d)
+        self.assertIn('a-peer0:', out)
+        self.assertIn('b-peer0:', out)
+        self.assertEqual(out.count('image: luthersystems/substrate:$CHAINCODE_VERSION'), 2)
+
+    def test_override_applies_only_to_named_service(self):
+        with tempfile.TemporaryDirectory() as d:
+            _make_net(d).generate_chaincodes_compose(
+                ['a', 'external'],
+                ['external=luthersystems/externalcc:$CHAINCODE_VERSION'])
+            out = _rendered(d)
+        a_block = out.split('a-peer0:', 1)[1].split('external-peer0:', 1)[0]
+        ext_block = out.split('external-peer0:', 1)[1]
+        self.assertIn('image: luthersystems/substrate:$CHAINCODE_VERSION', a_block)
+        self.assertIn('image: luthersystems/externalcc:$CHAINCODE_VERSION', ext_block)
+        self.assertNotIn('image: luthersystems/substrate', ext_block.split('\n', 5)[1])
+
+    def test_unknown_name_exits(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit) as cm:
+                _make_net(d).generate_chaincodes_compose(['a'], ['foo=bar:1'])
+            self.assertIn("'foo'", str(cm.exception))
+
+    def test_malformed_pair_exits(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit):
+                _make_net(d).generate_chaincodes_compose(['a'], ['no-equals-sign'])
+            with self.assertRaises(SystemExit):
+                _make_net(d).generate_chaincodes_compose(['a'], ['=bar'])
+            with self.assertRaises(SystemExit):
+                _make_net(d).generate_chaincodes_compose(['a'], ['a='])
+
+    def test_empty_cc_list_skips(self):
+        with tempfile.TemporaryDirectory() as d:
+            _make_net(d).generate_chaincodes_compose([])
+            self.assertFalse(os.path.exists(os.path.join(d, 'docker-compose-ccaas.yaml')))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `--image-override NAME=IMAGE` (repeatable) to `generatecc`, letting CCaaS services be launched under non-substrate images while other services stay on `luthersystems/substrate:$CHAINCODE_VERSION`. This unblocks substrate's [PR #274](https://github.com/luthersystems/substrate/pull/274) (converting `install-external` to CCaaS for Docker Engine v29 compatibility).
- Makes `image:` per-service in `docker-compose-ccaas.yaml.j2`; no-override output is byte-identical to pre-change.
- Introduces Python tests (stdlib `unittest` + PyYAML for structural assertions), a `make test` target, and a `test` CI job.
- **Drive-by**: bumps `Jinja2`, `cryptography`, `pyOpenSSL` to patched versions, closing all 9 open Dependabot alerts on main (2 high, 4 moderate, 3 low).

Closes #6.

## Behavior

```bash
fabric-network-builder generatecc --ccaas \
  --image-override external=luthersystems/externalcc:\$CHAINCODE_VERSION \
  mycc v1.0 "a b external" /path/to/chaincode.car
```
→ `external-peer0` runs `luthersystems/externalcc:...`, `a-peer0`/`b-peer0` stay on substrate default.

Validation: unknown `NAME`, duplicate `NAME`, malformed `NAME=IMAGE`, or `--image-override` without `--ccaas` all exit non-zero with a clear message.

## Dependency bumps

| Package | Old | New | Alerts closed |
|---|---|---|---|
| Jinja2 | 3.1.4 | 3.1.6 | 2× moderate (sandbox breakouts) |
| cryptography | 42.0.4 | 46.0.7 | 1× high (subgroup attack), 1× moderate + 2× low (OpenSSL bundled) |
| pyOpenSSL | 24.0.0 | 26.0.0 | 1× high (DTLS buffer overflow), 1× low (TLS bypass) |

Only pyOpenSSL is imported directly (`OpenSSL.crypto.load_certificate` / `FILETYPE_PEM` / `X509.get_notAfter()`) — all still present and non-deprecated in 26.0.0 (verified with a self-signed cert smoke test).

## Release

Per the ticket, cut `v0.0.5` after this lands (separate step — not in this PR).

## Test plan

- [x] `make test` passes locally (8 cases: default, override scope, value-contains-`=`, unknown NAME, malformed pair, duplicate NAME, requires --ccaas, empty cc list)
- [x] Tests parse via `yaml.safe_load` — catches YAML-invalidity regressions in the template
- [x] Manual render with `--image-override external=...` produces expected two-service compose
- [x] `diff` of no-override render vs pre-change render is empty (byte-identical)
- [x] `generatecc --help` shows `--image-override NAME=IMAGE`
- [x] Typo path exits with `NAME '...' is not in cc_variants`
- [x] pyOpenSSL 26 cert-expiry API smoke: `load_certificate(FILETYPE_PEM, …).get_notAfter()` works
- [x] CI: `test` + `build` both green