### PR TITLE
fix(deps): bump cryptography to 49.0.0 (Dependabot #11, vulnerable OpenSSL)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.1
 Jinja2==3.1.6
-cryptography==46.0.7
-pyOpenSSL==26.0.0
+cryptography==49.0.0
+pyOpenSSL==26.3.0


### PR DESCRIPTION
Resolves Dependabot alert **#11** (high) — *"Vulnerable OpenSSL included in cryptography wheels"* — which flags `cryptography < 48.0.1`. We pin `46.0.7`, so we're affected.

## Change
- `cryptography` 46.0.7 → **49.0.0** (≥ the 48.0.1 fix; latest stable)
- `pyOpenSSL` 26.0.0 → **26.3.0** — required, since pyOpenSSL 26.0.0 caps cryptography below 48 (pip resolves `ResolutionImpossible` otherwise); pyOpenSSL is still used by `cert_expiries`.

## Verification
- Full unit suite (36 tests) passes on the new stack (`cryptography 49.0.0 | pyOpenSSL 26.3.0`).
- No code changes needed — the `reissue` cert-signing path uses stable cryptography APIs.